### PR TITLE
Update extensions only if LURKER_UPGRADE env set

### DIFF
--- a/features/multitype_request_support.feature
+++ b/features/multitype_request_support.feature
@@ -59,7 +59,7 @@ Feature: multitype request support
     """
 
   Scenario: json schema tests response parameters and update request parameters using "users/update"
-    Given a file named "spec/controllers/api/v2/users_multitype_spec.rb" with:
+    Given a file named "spec/controllers/api/v2/users_controller_spec.rb" with:
       """ruby
         require "spec_helper"
 
@@ -67,17 +67,17 @@ Feature: multitype request support
           render_views
 
           let(:user) do
-            User.where(name: 'razum2um', surname: 'Marley').first_or_create!
+            User.where(name: 'razum2um', surname: 'Unknown').first_or_create!
           end
 
           it "updates a user surname as string" do
-            patch :update, id: user.id, user: { surname: 'Unknown' }
+            patch :update, id: user.id, user: { surname: 'Marley' }
             expect(response).to be_success
           end
         end
       """
 
-  When I run `bin/rspec spec/controllers/api/v2/users_multitype_spec.rb`
+  When I run `bin/rspec spec/controllers/api/v2/users_controller_spec.rb`
   Then the example should pass
   Then a file named "lurker/api/v2/users/__id-PATCH.json.yml" should exist
   Then the file "lurker/api/v2/users/__id-PATCH.json.yml" should contain exactly:
@@ -104,7 +104,7 @@ Feature: multitype request support
                 example: 42
               - description: ''
                 type: string
-                example: Unknown
+                example: Marley
     responseCodes:
     - status: 200
       successful: true

--- a/features/schema_updating_within_test_suite.feature
+++ b/features/schema_updating_within_test_suite.feature
@@ -58,7 +58,7 @@ Feature: schema updating within test suite
     """
 
   Scenario: json schema tests response parameters and update request parameters using "users/update"
-  Given a file named "spec/controllers/api/v2/users_fields_spec.rb" with:
+  Given a file named "spec/controllers/api/v2/users_controller_spec.rb" with:
     """ruby
       require "spec_helper"
 
@@ -76,7 +76,7 @@ Feature: schema updating within test suite
       end
     """
 
-  When I run `bin/rspec spec/controllers/api/v2/users_fields_spec.rb`
+  When I run `bin/rspec spec/controllers/api/v2/users_controller_spec.rb`
   Then the example should pass
   Then a file named "lurker/api/v2/users/__id-PATCH.json.yml" should exist
   Then the file "lurker/api/v2/users/__id-PATCH.json.yml" should contain exactly:

--- a/lib/lurker.rb
+++ b/lib/lurker.rb
@@ -1,7 +1,8 @@
 $:.unshift(File.dirname(__FILE__))
 
 module Lurker
-  DEFAULT_SERVICE_PATH = DEFAULT_URL_BASE = "lurker"
+  DEFAULT_SERVICE_PATH = DEFAULT_URL_BASE = "lurker".freeze
+  LURKER_UPGRADE = "LURKER_UPGRADE".freeze
 
   def self.safe_require(gem, desc=nil)
     begin
@@ -15,8 +16,8 @@ module Lurker
     yield if block_given?
   end
 
-  def self.scaffold_mode?
-    ENV['LURKER_SCAFFOLD']
+  def self.upgrade?
+    !!ENV[LURKER_UPGRADE]
   end
 
   def self.service_path=(service_path)

--- a/lib/lurker/schema.rb
+++ b/lib/lurker/schema.rb
@@ -2,7 +2,7 @@ require 'yaml'
 
 module Lurker
   class Schema
-    KEY = 'extensions'
+    EXTENSIONS = "extensions".freeze
     DESCRPTIONS = {
       'index' => 'listing',
       'show' => '',
@@ -16,9 +16,8 @@ module Lurker
     def initialize(json_schema_hash, extensions = {})
       @hash = json_schema_hash
 
-      existing_extensions = @hash.delete(KEY) || {}
-      @extensions = extensions.blank? ? existing_extensions
-                                      : extensions
+      existing_extensions = @hash.delete(EXTENSIONS) || {}
+      @extensions = select_extensions(existing_extensions, extensions)
     end
 
     def respond_to_missing?(method, include_private = false)
@@ -47,7 +46,7 @@ module Lurker
 
     def to_yaml
       YAML.dump(@hash.merge(
-        KEY => @extensions
+        EXTENSIONS => @extensions
       ))
     end
 
@@ -66,6 +65,14 @@ module Lurker
     end
 
     private
+
+    def select_extensions(existing, given)
+      if Lurker.upgrade? || (existing.blank? && given.present?)
+        given
+      else
+        existing
+      end
+    end
 
     def default_descrption
       "#{default_subject.singularize} #{DESCRPTIONS[path_params['action']]}"


### PR DESCRIPTION
Что сделано:
- `extensions` обновляются если установлена переменная окружения `LURKER_UPGRADE` или существующие — пустые
- Схлопнуты дублирующиеся спек файлы для кукумбера
- Немного заморозки
