### PR TITLE
Encode URL parameters

### DIFF
--- a/lib/lurker/templates/javascripts/lurker.js
+++ b/lib/lurker/templates/javascripts/lurker.js
@@ -46,7 +46,7 @@
     buildActionUrl: function(host, template, values) {
       for (var i = 0; i < values.length; i++) {
         var placeholder = new RegExp(':' + values[i].label);
-        template = template.replace(placeholder, values[i].value);
+        template = template.replace(placeholder, encodeURIComponent(values[i].value));
       }
       return host + template;
     },


### PR DESCRIPTION
Since we pass these parameters as a part of the URI, they should be properly encoded. Otherwise we will end up with invalid URI-s, like `/api/v1/labels/Some Label With Spaces`.