### PR TITLE
Include service description into PDF version of docs

### DIFF
--- a/lib/lurker/cli.rb
+++ b/lib/lurker/cli.rb
@@ -60,6 +60,7 @@ module Lurker
         inside(output_path) do
           service_presenters.each do |service_presenter|
             html = "<html><body>"
+            html << service_presenter.to_html(layout: false)
             service_presenter.endpoints.each do |endpoint_prefix_group|
               endpoint_prefix_group.each do |endpoint_presenter|
                 html << endpoint_presenter.to_html(layout: false)

--- a/lib/lurker/presenters/service_presenter.rb
+++ b/lib/lurker/presenters/service_presenter.rb
@@ -12,9 +12,9 @@ class Lurker::ServicePresenter < Lurker::BasePresenter
   end
 
   # TODO move to controller
-  def to_html(&block)
+  def to_html(options={}, &block)
     @service_presenter = self
-    render('index')
+    render('index', options)
   end
 
   def title

--- a/lib/lurker/templates/lurker/rendering/show.html.erb
+++ b/lib/lurker/templates/lurker/rendering/show.html.erb
@@ -5,7 +5,7 @@
 
 <pre><%= @endpoint_presenter.verb %> <%= @endpoint_presenter.named_path %></pre>
 
-<h3>Example</h3>
+<h3>Response Example</h3>
 <%= render 'submit_form' %>
 
 <div id="show-api-response-div" class="highlight">

--- a/lib/lurker/templates/stylesheets/application.scss
+++ b/lib/lurker/templates/stylesheets/application.scss
@@ -30,3 +30,6 @@
 .table-condensed td, .table-condensed th {
   padding: 0;
 }
+.page-header {
+  page-break-before: always;
+}


### PR DESCRIPTION
A PDF generated by `lurker convert -f pdf -c api.md` will now include service description.