### PR TITLE
Support array of types

### DIFF
--- a/lib/lurker/json/parser/expertise.rb
+++ b/lib/lurker/json/parser/expertise.rb
@@ -13,7 +13,7 @@ module Lurker
         def type_defined?(hash)
           return false unless hash.is_a?(Hash)
 
-          hash.key?(Json::TYPE) && Json::PRIMITIVES.include?(hash[Json::TYPE])
+          hash.key?(Json::TYPE) && valid_type?(hash[Json::TYPE])
         end
 
         def type_supposed?(hash)
@@ -22,6 +22,11 @@ module Lurker
           hash.key?(Json::ANYOF) || hash.key?(Json::ALLOF) || hash.key?(Json::ONEOF) ||
           hash.key?(Json::ITEMS) || hash.key?(Json::PROPERTIES) ||
           hash.key?(Json::REF)
+        end
+
+        def valid_type?(type)
+          return Json::PRIMITIVES.include?(type) unless type.is_a?(Array)
+          !type.empty? && type.all? { |t| Json::PRIMITIVES.include?(t) }
         end
       end
     end

--- a/spec/lurker/json/parser_spec.rb
+++ b/spec/lurker/json/parser_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Lurker::Json::Parser do
+  let(:klass) { described_class }
+
+  describe "#parse" do
+    context "typed" do
+      subject { described_class.typed.parse(payload) }
+
+      context "with empty hash" do
+        let(:payload) { {} }
+        let(:expected) do
+          {
+            "additionalProperties" => false,
+            "description" => "",
+            "properties" => {},
+            "required" => [],
+            "type" => "object"
+          }
+        end
+
+        specify { expect(subject.to_hash).to eq expected }
+      end
+
+      context "with several types" do
+        let(:payload) { { "type" => ["string", "null"] } }
+
+        let(:expected) do
+          {
+            "description" => "",
+            "type" => ["string", "null"],
+            "example" => ""
+          }
+        end
+
+        specify { expect(subject.to_hash).to eq expected }
+      end
+
+      context "with items" do
+        let(:payload) { { "items" => [] } }
+
+        specify { expect(subject.to_hash).to include("type" => "array") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
According to [specs](http://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.2), "type" can also be an array of primitive types.

I've also added some specs for parser.
